### PR TITLE
Delay emit until user presses enter

### DIFF
--- a/examples/urwZOCP.py
+++ b/examples/urwZOCP.py
@@ -232,7 +232,7 @@ class ZOCPKeyboardWidget(urwid.Edit):
         """
         Render the widget.
         
-        `render` is overridden so we can generate `focus_event` events 
+        `render` is overridden so we can generate `on_focus` events 
         when the focus argument changes 
 
         :param size: see `urwid.Widget.render(size, focus)`
@@ -243,11 +243,11 @@ class ZOCPKeyboardWidget(urwid.Edit):
         """
         if focus != self.focused:
             self.focused = focus
-            self.focus_event(focus)
+            self.on_focus(focus)
 
         return self.__super.render(size, focus)
 
-    def focus_event(self, focus):
+    def on_focus(self, focus):
         """
         Handle changes in focus.
         


### PR DESCRIPTION
The current urwZOCP shouts out changes in string-, int- and float-widgets while typing. For changes in (long) strings and ints, as well as keyboard-changes in floats, it would be better if there is one shout at a controllable point in time.

This pull-request subclasses the urwid.Edit widget so it can listen to getting/losing focus and respond to pressing enter. The current value is emitted automatically when pressing enter, and - if the value has been changed by the user - when the widget looses focus.
