### PR TITLE
Do not test in python 2.7 for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.7"
   - "3.2"
   - "3.3"
   - "3.4"


### PR DESCRIPTION
pyZOCP is currently not compatible with Python 2.7.
