### PR TITLE
Compatibility with Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "2.7"
   - "3.2"
   - "3.3"
   - "3.4"

--- a/examples/signal_3rdparty.py
+++ b/examples/signal_3rdparty.py
@@ -11,13 +11,13 @@ class SubscriptionMakerNode(ZOCP):
         self.subscribe = False
         self.subscriber_peer = None
         self.subscribee_peer = None
-        ZOCP.__init__(self)
+        super(SubscriptionMakerNode, self).__init__()
 
     def run(self):
         self.set_name(self.nodename)
         self.register_bool("Subscribe 'My String'", self.subscribe, 'rw')
         self.start()
-        ZOCP.run(self)
+        super(SubscriptionMakerNode, self).run()
         
     def on_peer_enter(self, peer, name, *args, **kwargs):
         split_name = name.split("@",1)

--- a/examples/signal_3rdparty.py
+++ b/examples/signal_3rdparty.py
@@ -11,13 +11,13 @@ class SubscriptionMakerNode(ZOCP):
         self.subscribe = False
         self.subscriber_peer = None
         self.subscribee_peer = None
-        super().__init__()
+        ZOCP.__init__(self)
 
     def run(self):
         self.set_name(self.nodename)
         self.register_bool("Subscribe 'My String'", self.subscribe, 'rw')
         self.start()
-        super().run()
+        ZOCP.run(self)
         
     def on_peer_enter(self, peer, name, *args, **kwargs):
         split_name = name.split("@",1)

--- a/examples/signal_subscribee.py
+++ b/examples/signal_subscribee.py
@@ -13,7 +13,7 @@ class SubscribableNode(ZOCP):
         self.count_value = 0
         self.counter_active = False
         self.string_value = ''
-        ZOCP.__init__(self)
+        super(SubscribableNode, self).__init__()
 
 
     def run(self):
@@ -25,12 +25,12 @@ class SubscribableNode(ZOCP):
         self.start()
 
         self.stop_timer = self.call_repeatedly(1, self.on_timer)
-        ZOCP.run(self)
+        super(SubscribableNode, self).run()
 
     
     def stop(self):
         self.stop_timer()
-        ZOCP.stop(self)
+        super(SubscribableNode, self).stop()
 
 
     def on_modified(self, peer, name, data, *args, **kwargs):

--- a/examples/signal_subscribee.py
+++ b/examples/signal_subscribee.py
@@ -13,7 +13,7 @@ class SubscribableNode(ZOCP):
         self.count_value = 0
         self.counter_active = False
         self.string_value = ''
-        super().__init__()
+        ZOCP.__init__(self)
 
 
     def run(self):
@@ -25,12 +25,12 @@ class SubscribableNode(ZOCP):
         self.start()
 
         self.stop_timer = self.call_repeatedly(1, self.on_timer)
-        super().run()
+        ZOCP.run(self)
 
     
     def stop(self):
         self.stop_timer()
-        super().stop()
+        ZOCP.stop(self)
 
 
     def on_modified(self, peer, name, data, *args, **kwargs):

--- a/examples/signal_subscriber.py
+++ b/examples/signal_subscriber.py
@@ -10,14 +10,14 @@ class SubscriberNode(ZOCP):
         self.nodename = nodename
         self.string_value = ''
         self.count_value = 0
-        super().__init__()
+        ZOCP.__init__(self)
 
     def run(self):
         self.set_name(self.nodename)
         self.register_string("My String", self.string_value, 'rws')
         self.register_int("Linked counter", self.count_value, 'rs')
         self.start()
-        super().run()
+        ZOCP.run(self)
         
     def on_peer_enter(self, peer, name, *args, **kwargs):
         split_name = name.split("@",1)

--- a/examples/signal_subscriber.py
+++ b/examples/signal_subscriber.py
@@ -10,14 +10,14 @@ class SubscriberNode(ZOCP):
         self.nodename = nodename
         self.string_value = ''
         self.count_value = 0
-        ZOCP.__init__(self)
+        super(SubscriberNode, self).__init__()
 
     def run(self):
         self.set_name(self.nodename)
         self.register_string("My String", self.string_value, 'rws')
         self.register_int("Linked counter", self.count_value, 'rs')
         self.start()
-        ZOCP.run(self)
+        super(SubscriberNode, self).run()
         
     def on_peer_enter(self, peer, name, *args, **kwargs):
         split_name = name.split("@",1)

--- a/examples/urwZOCP.py
+++ b/examples/urwZOCP.py
@@ -44,7 +44,7 @@ def mergedicts(a, b, path=None):
 class ZmqEventLoop(urwid.SelectEventLoop):
 
     def __init__(self, ctx=zmq.Context(), *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super(ZmqEventLoop, self).__init__(*args, **kwargs)
         self._zctx = ctx
         self._zpoller = zmq.Poller()
 
@@ -147,7 +147,7 @@ class PopUpDialog(urwid.WidgetWrap):
 
 class HeadingWithPopUp(urwid.PopUpLauncher):
     def __init__(self, name):
-        super().__init__(urwid.Button(name))
+        super(HeadingWithPopUp, self).__init__(urwid.Button(name))
         urwid.connect_signal(self.original_widget, 'click',
             lambda button: self.open_pop_up())
 
@@ -164,7 +164,7 @@ class UrwStdWriter(io.TextIOWrapper):
     
     def __init__(self, *args, **kwargs):
         self.wgt = urwid.Text("")
-        super().__init__(*args, **kwargs)
+        super(UrwStdWriter, self).__init__(*args, **kwargs)
 
     def write(self, data):
         self.wgt.set_text("%s%s" %(self.wgt.get_text()[0], data))
@@ -181,7 +181,7 @@ class ZOCPProgressBar(urwid.ProgressBar):
     def __init__(self, sel_normal, sel_complete, *args, **kwargs):
         self.sel_normal = sel_normal
         self.sel_complete = sel_complete
-        super().__init__(*args, **kwargs)
+        super(ZOCPProgressBar, self).__init__(*args, **kwargs)
 
     def set_label(self, label):
         self._label, self._attrib = decompose_tagmarkup(caption)
@@ -221,7 +221,7 @@ class ZOCPKeyboardWidget(urwid.Edit):
         pressing enter or when leaving widget
         """
         (maxcol,) = size
-        unhandled = super().keypress((maxcol,),key)
+        unhandled = super(ZOCPKeyboardWidget, self).keypress((maxcol,),key)
 
         if key == 'enter':
             self.set_val = self.value()
@@ -344,7 +344,7 @@ class ZOCPIntWidget(ZOCPKeyboardWidget):
         2
         """
         (maxcol,) = size
-        unhandled = super().keypress((maxcol,),key)
+        unhandled = super(ZOCPIntWidget, self).keypress((maxcol,),key)
 
         if not unhandled:
         # trim leading zeros
@@ -408,7 +408,7 @@ class ZOCPFloatWidget(ZOCPKeyboardWidget):
         self.min = min
         self.max = max
         self.step = step
-        super().__init__(caption, "%f" %value)
+        super(ZOCPFloatWidget).__init__(caption, "%f" %value)
         #rwid.connect_signal(self, 'change', self.on_change)
 
     def keypress(self, size, key):
@@ -439,7 +439,7 @@ class ZOCPFloatWidget(ZOCPKeyboardWidget):
             self.set_val = val
             self._emit("change", val)
         else:
-            unhandled = super().keypress((maxcol,),key)
+            unhandled = super(ZOCPFloatWidget, self).keypress((maxcol,),key)
 
             if not unhandled:
             # trim leading zeros
@@ -503,7 +503,7 @@ class ZOCPVec2fWidget(ZOCPKeyboardWidget):
         self.min = min
         self.max = max
         self.step = step
-        super().__init__(caption, "[%.3f, %.3f]" %(value[0], value[1]))
+        super(ZOCPVec2fWidget, self).__init__(caption, "[%.3f, %.3f]" %(value[0], value[1]))
 
     def keypress(self, size, key):
         """
@@ -532,7 +532,7 @@ class ZOCPVec2fWidget(ZOCPKeyboardWidget):
             self.set_value(val)
             self._emit("change", val)
         else:
-            unhandled = super().keypress((maxcol,),key)
+            unhandled = super(ZOCPVec2fWidget, self).keypress((maxcol,),key)
 
             if not unhandled:
             # trim leading zeros
@@ -583,7 +583,7 @@ class ZOCPNodeWidget(urwid.WidgetWrap):
         self.focused = False
         self._update_widgets()
         display_widget = urwid.Pile(urwid.SimpleFocusListWalker(self._widgets))
-        super().__init__(display_widget)
+        super(ZOCPNodeWidget, self).__init__(display_widget)
 
     def update(self, data=None):
         if isinstance(data, dict):
@@ -698,7 +698,7 @@ focus_map_pg = {
 class urwZOCP(zocp.ZOCP):
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super(urwZOCP, self).__init__(*args, **kwargs)
         self.oldout = sys.stdout
         self.out = UrwStdWriter(io.BytesIO(), sys.stdout.encoding)
         self.znodes = {}

--- a/src/zocp.py
+++ b/src/zocp.py
@@ -79,7 +79,7 @@ def dict_merge(a, b, path=None):
 class ZOCP(Pyre):
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super(ZOCP, self).__init__(*args, **kwargs)
         self.subscriptions = {}
         self.subscribers = {}
         self.set_header("X-ZOCP", "1")

--- a/tests/test_zocp.py
+++ b/tests/test_zocp.py
@@ -2,6 +2,12 @@ import unittest
 import zocp
 import zmq
 import time
+import sys
+
+
+if sys.version.startswith('3'):
+    unicode = str
+
 
 class ZOCPTest(unittest.TestCase):
     
@@ -41,8 +47,8 @@ class ZOCPTest(unittest.TestCase):
         id1 = self.node1.get_uuid()
         id2 = self.node2.get_uuid()
 
-        self.assertIsInstance(self.node1.get_peer_address(id2), str)
-        self.assertIsInstance(self.node2.get_peer_address(id1), str)
+        self.assertIsInstance(self.node1.get_peer_address(id2), unicode)
+        self.assertIsInstance(self.node2.get_peer_address(id1), unicode)
     # end test_get_peer_address
 
     def test_get_peer_header_value(self):


### PR DESCRIPTION
Now Pyre is compatible with Python 2.7, so can pyZOCP be compatible. This patch fixes mostly the examples to use super() more correctly.