### PR TITLE
Add list of sensors to on_peer_signaled

### DIFF
--- a/examples/signal_3rdparty.py
+++ b/examples/signal_3rdparty.py
@@ -37,7 +37,9 @@ class SubscriptionMakerNode(ZOCP):
 
     def on_peer_signaled(self, peer, name, data, *args, **kwargs):
         if self._running and peer:
-            self.receive_value(data[0])
+            for sensor in data[2]:
+                if(sensor):
+                    self.receive_value(sensor)
 
     def receive_value(self, key):
         new_value = self.capability[key]['value']

--- a/examples/signal_subscribee.py
+++ b/examples/signal_subscribee.py
@@ -42,7 +42,9 @@ class SubscribableNode(ZOCP):
                 
     def on_peer_signaled(self, peer, name, data, *args, **kwargs):
         if self._running and peer:
-            self.receive_value(data[0])
+            for sensor in data[2]:
+                if(sensor):
+                    self.receive_value(sensor)
 
 
     def receive_value(self, key):

--- a/src/zocp.py
+++ b/src/zocp.py
@@ -502,9 +502,11 @@ class ZOCP(Pyre):
 
         peer: id of peer whose data has been changed
         name: name of peer whose data has been changed
-        data: changed data, formatted as [emitter, value]
+        data: changed data, formatted as [emitter, value, [sensors1, ...]]
               emitter: name of the emitter on the subscribee
               value: value of the emitter
+              [sensor1,...]: list of names of sensors on the subscriber
+                             receiving the signal
         """
         logger.debug("ZOCP PEER SIGNALED: %s modified %s" %(name, data))
 
@@ -731,9 +733,15 @@ class ZOCP(Pyre):
         if peer in self.subscriptions:
             subscription = self.subscriptions[peer]
             if emitter in subscription:
-                # propagate the signal if it changes the value of this node
                 receivers = subscription[emitter]
                 for receiver in receivers:
+                    # add a list of sensors on this node receiving the signal
+                    if len(data) == 2:
+                        data.append([receiver])
+                    else:
+                        data[2].append(receiver)
+
+                    # propagate the signal if it changes the value of this node
                     if receiver is not None and self.capability[receiver]['value'] != value:
                         self.emit_signal(receiver, value)
 


### PR DESCRIPTION
Currently the on_peer_signaled callback has access to the emitter name and the new value, but not to the sensor on the current node that is subscribed to the signal. If the node uses on_peer_signaled to respond to a signal it is very useful to know what sensor in the node received the signal. 

This patch is for an oversight in the signals work. Behind the scenes zocp has already updated the value in the capability tree (which is why this oversight went unnoticed for a while). The patch adds a list of sensor names to the data argument of the on_peer_signaled call, thus keeping the signature of the callback the same. Note that a signal from one emitter can be sent to several sensors in a node, so the data argument now contains a _list_ of sensors.
