### PR TITLE
Zyre api changes

### DIFF
--- a/examples/BpyZOCP.py
+++ b/examples/BpyZOCP.py
@@ -108,7 +108,6 @@ class BpyZOCP(ZOCP):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.set_name("Blender@" + socket.gethostname() + ":" + bpy.app.version_string)
         self.start()
 
     @persistent
@@ -296,7 +295,7 @@ class BpyZOCP(ZOCP):
     #except (KeyboardInterrupt, SystemExit):
     #        self.stop()
 
-z = BpyZOCP()
+z = BpyZOCP("Blender@" + socket.gethostname() + ":" + bpy.app.version_string)
 
 compobj = {}
 for ob in bpy.data.objects:

--- a/examples/glib_node.py
+++ b/examples/glib_node.py
@@ -7,8 +7,7 @@ import zmq
 GObject.threads_init()
 loop = GObject.MainLoop()
 
-z = ZOCP()
-z.set_node_name("GLibTest")
+z = ZOCP("GLibTest")
 z.register_percent('myPercent', 12, access='rw')
 
 def zocp_handle(*args, **kwargs):

--- a/examples/qt_ui_node.py
+++ b/examples/qt_ui_node.py
@@ -21,8 +21,7 @@ class QTZOCPNode(QtWidgets.QWidget):
         self.show()
 
     def init_zocp(self):
-        self.z = ZOCP()
-        self.z.set_node_name("QT UI TEST")
+        self.z = ZOCP("QT UI TEST")
         self.z.register_float("myFloat", 2.3, 'rw', 0, 5.0, 0.1)
         self.notifier = QtCore.QSocketNotifier(
                 self.z.inbox.getsockopt(zmq.FD), 

--- a/examples/signal_subscriber.py
+++ b/examples/signal_subscriber.py
@@ -22,8 +22,8 @@ class SubscriberNode(ZOCP):
     def on_peer_enter(self, peer, name, *args, **kwargs):
         split_name = name.split("@",1)
         if(split_name[0] == 'subscribee'):
-            #self.signal_subscribe(self.get_uuid(), 'My String', peer, 'My String')
-            self.signal_subscribe(self.get_uuid(), 'Linked counter', peer, 'Counter')
+            #self.signal_subscribe(self.uuid(), 'My String', peer, 'My String')
+            self.signal_subscribe(self.uuid(), 'Linked counter', peer, 'Counter')
     
         
 if __name__ == '__main__':

--- a/examples/urwZOCP.py
+++ b/examples/urwZOCP.py
@@ -734,7 +734,7 @@ class urwZOCP(zocp.ZOCP):
             #cells.contents.insert(index, (nd, ('given', 20)))
             self.cells.contents.append(self.znodes[peer])
             
-        self.signal_subscribe(self.get_uuid(), None, peer, None)
+        self.signal_subscribe(self.uuid(), None, peer, None)
 
     def on_peer_exit(self, peer, name, *args, **kwargs):
         print("ZOCP EXIT    : %s" %(name))

--- a/examples/urwZOCP.py
+++ b/examples/urwZOCP.py
@@ -772,5 +772,5 @@ class urwZOCP(zocp.ZOCP):
 
 if __name__ == "__main__":
     ctx = zmq.Context()
-    z = urwZOCP(ctx=ctx)
+    z = urwZOCP("urwMonitor", ctx=ctx)
     z.run()

--- a/src/zocp.py
+++ b/src/zocp.py
@@ -814,8 +814,7 @@ class ZOCP(Pyre):
 
 if __name__ == '__main__':
 
-    z = ZOCP()
-    z.set_node_name("ZOCP-Test")
+    z = ZOCP("ZOCP-Test")
     z.register_bool("zocpBool", True, 'rw')
     z.register_float("zocpFloat", 2.3, 'rw', 0, 5.0, 0.1)
     z.register_int('zocpInt', 10, access='rw', min=-10, max=10, step=1)

--- a/src/zocp.py
+++ b/src/zocp.py
@@ -122,8 +122,8 @@ class ZOCP(Pyre):
         Return node's name
         """
         # Is handled by Pyre
-        logger.warning("DEPRECATED: get_node_name is deprecated, use get_name")
-        return self.get_name()
+        logger.warning("DEPRECATED: get_node_name is deprecated, use name")
+        return self.name()
 
     def set_node_location(self, location=[0,0,0]):
         """
@@ -348,7 +348,7 @@ class ZOCP(Pyre):
         is then sent to the emitter node which in turn forwards the
         subscribtion request to the receiver node.
         """
-        if recv_peer == self.get_uuid():
+        if recv_peer == self.uuid():
             # we are the receiver so register the emitter
             peer_subscriptions = {}
             if emit_peer in self.subscriptions:
@@ -385,7 +385,7 @@ class ZOCP(Pyre):
         is then sent to the emitter node which in turn forwards the
         subscribtion request to the receiver node.
         """
-        if recv_peer == self.get_uuid():
+        if recv_peer == self.uuid():
             # we are the receiver so unregister the emitter
             if (emit_peer in self.subscriptions and
                     emitter in self.subscriptions[emit_peer] and
@@ -540,7 +540,7 @@ class ZOCP(Pyre):
         grp=None
         if type == "ENTER":
             # This is giving conflicts when using a poller, in discussion
-            #if not self.get_peer_header_value(peer, "X-ZOCP"):
+            #if not self.peer_header_value(peer, "X-ZOCP"):
             #    logger.debug("Node is not a ZOCP node")
             #    return
 
@@ -641,7 +641,7 @@ class ZOCP(Pyre):
     def _handle_SUB(self, data, peer, name, grp):
         [emit_peer, emitter, recv_peer, receiver] = data
 
-        node_id = self.get_uuid()
+        node_id = self.uuid()
         recv_peer = uuid.UUID(recv_peer)
         emit_peer = uuid.UUID(emit_peer)
         if emit_peer != node_id and recv_peer != node_id:
@@ -680,7 +680,7 @@ class ZOCP(Pyre):
     def _handle_UNSUB(self, data, peer, name, grp):
         [emit_peer, emitter, recv_peer, receiver] = data
 
-        node_id = self.get_uuid()
+        node_id = self.uuid()
         recv_peer = uuid.UUID(recv_peer)
         emit_peer = uuid.UUID(emit_peer)
         if emit_peer != node_id and recv_peer != node_id:

--- a/tests/test_zocp.py
+++ b/tests/test_zocp.py
@@ -30,56 +30,56 @@ class ZOCPTest(unittest.TestCase):
         self.node2.stop()
     # end tearDown
 
-    def test_get_name(self):
-        self.assertEqual("node1", self.node1.get_name())
-        self.assertEqual("node2", self.node2.get_name())
-    # end test_get_name
+    def test_name(self):
+        self.assertEqual("node1", self.node1.name())
+        self.assertEqual("node2", self.node2.name())
+    # end test_name
 
-    def test_get_peers(self):
-        id1 = self.node1.get_uuid()
-        peers = self.node2.get_peers()
+    def test_peers(self):
+        id1 = self.node1.uuid()
+        peers = self.node2.peers()
 
         self.assertIsInstance(peers, list)
         self.assertIn(id1, peers)
-    # end test_get_peers
+    # end test_peers
 
-    def test_get_peer_address(self):
-        id1 = self.node1.get_uuid()
-        id2 = self.node2.get_uuid()
+    def test_peer_address(self):
+        id1 = self.node1.uuid()
+        id2 = self.node2.uuid()
 
-        self.assertIsInstance(self.node1.get_peer_address(id2), unicode)
-        self.assertIsInstance(self.node2.get_peer_address(id1), unicode)
-    # end test_get_peer_address
+        self.assertIsInstance(self.node1.peer_address(id2), unicode)
+        self.assertIsInstance(self.node2.peer_address(id1), unicode)
+    # end test_peer_address
 
-    def test_get_peer_header_value(self):
-        id1 = self.node1.get_uuid()
-        id2 = self.node2.get_uuid()
+    def test_peer_header_value(self):
+        id1 = self.node1.uuid()
+        id2 = self.node2.uuid()
 
-        self.assertEqual("1", self.node1.get_peer_header_value(id2, "X-TEST"))
-        self.assertEqual("1", self.node2.get_peer_header_value(id1, "X-TEST"))
-    # end test_get_peer_header_value
+        self.assertEqual("1", self.node1.peer_header_value(id2, "X-TEST"))
+        self.assertEqual("1", self.node2.peer_header_value(id1, "X-TEST"))
+    # end test_peer_header_value
 
-    def test_get_own_groups(self):
+    def test_own_groups(self):
         self.node1.join("TEST")
         self.node2.join("TEST")
 
         # pyre works asynchronous so give some time to let changes disperse
         time.sleep(0.5)
 
-        self.assertIn("TEST", self.node1.get_own_groups())
-        self.assertIn("TEST", self.node2.get_own_groups())
-    # end test_get_own_groups
+        self.assertIn("TEST", self.node1.own_groups())
+        self.assertIn("TEST", self.node2.own_groups())
+    # end test_own_groups
 
-    def test_get_peer_groups(self):
+    def test_peer_groups(self):
         self.node1.join("TEST")
         self.node2.join("TEST")
 
         # pyre works asynchronous so give some time to let changes disperse
         time.sleep(0.5)
 
-        self.assertIn("TEST", self.node1.get_peer_groups())
-        self.assertIn("TEST", self.node2.get_peer_groups())
-    # end test_get_peer_groups
+        self.assertIn("TEST", self.node1.peer_groups())
+        self.assertIn("TEST", self.node2.peer_groups())
+    # end test_peer_groups
 
     def test_signal_subscribe(self):
         self.node1.register_float("TestEmitFloat", 1.0, 'rwe')
@@ -87,19 +87,19 @@ class ZOCPTest(unittest.TestCase):
         # give time for dispersion
         self.node1.run_once()
         self.node2.run_once()
-        self.node2.signal_subscribe(self.node2.get_uuid(), "TestRecvFloat", self.node1.get_uuid(), "TestEmitFloat")
+        self.node2.signal_subscribe(self.node2.uuid(), "TestRecvFloat", self.node1.uuid(), "TestEmitFloat")
         # give time for dispersion
         time.sleep(0.5)
         self.node1.run_once()
         # subscriptions structure: {Emitter nodeID: {'EmitterID': ['Local ReceiverID']}}
-        self.assertIn("TestRecvFloat", self.node2.subscriptions[self.node1.get_uuid()]["TestEmitFloat"])
-        self.assertIn("TestRecvFloat", self.node1.subscribers[self.node2.get_uuid()]["TestEmitFloat"])
+        self.assertIn("TestRecvFloat", self.node2.subscriptions[self.node1.uuid()]["TestEmitFloat"])
+        self.assertIn("TestRecvFloat", self.node1.subscribers[self.node2.uuid()]["TestEmitFloat"])
         # unsubscribe
-        self.node2.signal_unsubscribe(self.node2.get_uuid(), "TestRecvFloat", self.node1.get_uuid(), "TestEmitFloat")
+        self.node2.signal_unsubscribe(self.node2.uuid(), "TestRecvFloat", self.node1.uuid(), "TestEmitFloat")
         time.sleep(0.5)
         self.node1.run_once()
-        self.assertNotIn("TestRecvFloat", self.node2.subscriptions.get(self.node1.get_uuid(), {}).get("TestEmitFloat", {}))
-        self.assertNotIn("TestRecvFloat", self.node1.subscribers.get(self.node2.get_uuid(), {}).get("TestEmitFloat", {}))
+        self.assertNotIn("TestRecvFloat", self.node2.subscriptions.get(self.node1.uuid(), {}).get("TestEmitFloat", {}))
+        self.assertNotIn("TestRecvFloat", self.node1.subscribers.get(self.node2.uuid(), {}).get("TestEmitFloat", {}))
 
     def test_emit_signal(self):
         self.node1.register_float("TestEmitFloat", 1.0, 'rwe')
@@ -107,7 +107,7 @@ class ZOCPTest(unittest.TestCase):
         # give time for dispersion
         time.sleep(0.5)
         self.node1.run_once()
-        self.node2.signal_subscribe(self.node2.get_uuid(), "TestRecvFloat", self.node1.get_uuid(), "TestEmitFloat")
+        self.node2.signal_subscribe(self.node2.uuid(), "TestRecvFloat", self.node1.uuid(), "TestEmitFloat")
         # give time for dispersion
         time.sleep(0.1)
         self.node1.run_once()
@@ -116,7 +116,7 @@ class ZOCPTest(unittest.TestCase):
         self.node2.run_once()
         self.assertEqual(2.0, self.node2.capability["TestRecvFloat"]["value"])
         # unsubscribe
-        self.node2.signal_unsubscribe(self.node2.get_uuid(), "TestRecvFloat", self.node1.get_uuid(), "TestEmitFloat")
+        self.node2.signal_unsubscribe(self.node2.uuid(), "TestRecvFloat", self.node1.uuid(), "TestEmitFloat")
         time.sleep(0.1)
         self.node1.run_once()
 # end ZOCPTest


### PR DESCRIPTION
As Pyre has changed its api here are the changes for ZOCP

Most important changes can be automatically done by a simple sed script:
```
sed -i 's/get_uuid/uuid/g' $1
sed -i 's/get_peer_groups/peer_groups/g' $1
sed -i 's/get_own_groups/own_groups/g' $1
sed -i 's/get_name/name/g' $1
sed -i 's/get_peers/peers/g' $1
sed -i 's/get_peer_address/peer_address/g' $1
sed -i 's/get_peer_header_value/peer_header_value/g' $1
```