### PR TITLE
Allow custom message handlers, extending the basic ZOCP protocol

### DIFF
--- a/src/zocp.py
+++ b/src/zocp.py
@@ -613,7 +613,7 @@ class ZOCP(Pyre):
                     try:
                         func = getattr(self, 'handle_'+method)
                         func(msg[method], peer, name, grp)
-                    except:
+                    except AttributeError:
                         logger.warning('No method to handle message of type %s' % method)
 
     def _handle_GET(self, data, peer, name, grp=None):

--- a/src/zocp.py
+++ b/src/zocp.py
@@ -612,9 +612,9 @@ class ZOCP(Pyre):
                 else:
                     try:
                         func = getattr(self, 'handle_'+method)
-                        func(msg[method])
+                        func(msg[method], peer, name, grp)
                     except:
-                        raise Exception('No %s method on resource: %s' %(method,object))
+                        logger.warning('No method to handle message of type %s' % method)
 
     def _handle_GET(self, data, peer, name, grp=None):
         """


### PR DESCRIPTION
The current implementation almost (but not quite) allows for adding handlers for custom messages besides the ZOCP messages (GET, MOD, SIG, SUB, UNSUB, etc). In the current implementation a node can add a custom handler (`handle_SMTHNG()`), but any node not implementing that handler and receiving a `SMTHNG` message will raise an exception. This patch replaces that exception with a warning, allowing the node to continue, ignoring the custom message.

An example of a custom message implementation can be seen here:
https://github.com/fieldOfView/pyZTime
This example uses custom messages (`DTIME_GET` and `DTIME_REP`) to implement a distributed timer.