### PR TITLE
fixed late subscription problems. 

### DIFF
--- a/src/zocp.py
+++ b/src/zocp.py
@@ -296,6 +296,22 @@ class ZOCP(Pyre):
         """
         self._register_param(name, vec4f, 'vec4f', access, min, max, step)
 
+    def get_value(self, name):
+        """
+        Retrieve the current value of a named parameter in the capability tree
+
+        Arguments:
+        * name: the name of the parameter in the capability tree
+
+        returns the value of the parameter or None
+
+        Note:
+            This is a temporary convenience method
+        """
+        # TODO: could use dict_get(self.capability, keys)
+        # for nested values
+        return self.capability[name]['value']
+
     #########################################
     # Node methods to peers
     #########################################

--- a/tests/test_zocp.py
+++ b/tests/test_zocp.py
@@ -120,8 +120,8 @@ class ZOCPTest(unittest.TestCase):
         self.node1.signal_unsubscribe(self.node2.uuid(), "TestRecvFloat", self.node1.uuid(), "TestEmitFloat")
         #time.sleep(0.5)
         self.node2.run_once(5)
-        #self.assertNotIn("TestRecvFloat", self.node2.subscriptions.get(self.node1.uuid(), {}).get("TestEmitFloat", {}))
-        #self.assertNotIn("TestRecvFloat", self.node1.subscribers.get(self.node2.uuid(), {}).get("TestEmitFloat", {}))
+        self.assertNotIn("TestRecvFloat", self.node2.subscriptions.get(self.node1.uuid(), {}).get("TestEmitFloat", {}))
+        self.assertNotIn("TestRecvFloat", self.node1.subscribers.get(self.node2.uuid(), {}).get("TestEmitFloat", {}))
 
     def test_emit_signal(self):
         self.node1.register_float("TestEmitFloat", 1.0, 'rwe')

--- a/tests/test_zocp.py
+++ b/tests/test_zocp.py
@@ -120,6 +120,7 @@ class ZOCPTest(unittest.TestCase):
         self.node1.signal_unsubscribe(self.node2.uuid(), "TestRecvFloat", self.node1.uuid(), "TestEmitFloat")
         #time.sleep(0.5)
         self.node2.run_once(5)
+        self.node1.run_once(5)
         self.assertNotIn("TestRecvFloat", self.node2.subscriptions.get(self.node1.uuid(), {}).get("TestEmitFloat", {}))
         self.assertNotIn("TestRecvFloat", self.node1.subscribers.get(self.node2.uuid(), {}).get("TestEmitFloat", {}))
 

--- a/tests/test_zocp.py
+++ b/tests/test_zocp.py
@@ -79,6 +79,13 @@ class ZOCPTest(unittest.TestCase):
         self.assertIn("TEST", self.node2.peer_groups())
     # end test_peer_groups
 
+    def test_get_value(self):
+        self.node1.register_float("TestEmitFloat", 1.0, 'rwe')
+        self.node2.register_float("TestRecvFloat", 1.0, 'rws')
+        self.assertEqual(self.node1.get_value("TestEmitFloat"), 1.0)
+        self.assertEqual(self.node2.get_value("TestRecvFloat"), 1.0)
+    # end test_get_value
+
     def test_signal_subscribe(self):
         self.node1.register_float("TestEmitFloat", 1.0, 'rwe')
         self.node2.register_float("TestRecvFloat", 1.0, 'rws')

--- a/tests/test_zocp.py
+++ b/tests/test_zocp.py
@@ -116,6 +116,13 @@ class ZOCPTest(unittest.TestCase):
         self.node2.run_once(5)
         self.node1.signal_subscribe(self.node2.uuid(), "TestRecvFloat", self.node1.uuid(), "TestEmitFloat")
         # give time for dispersion
+        # a subscription results in:
+        # * whisper MOD, to update subscribers (self._on_modified)
+        # * whisper SUB, to the receiver or emitter
+        # We need to receive:
+        # * a forwarded SUB (in case of self emitter subscribe)
+        # * a MOD of the peer
+        # so we need to do two runs on both nodes
         self.node2.run_once(5)
         self.node1.run_once(5)
         self.node2.run_once(5)
@@ -125,7 +132,15 @@ class ZOCPTest(unittest.TestCase):
         self.assertIn("TestRecvFloat", self.node2.subscriptions[self.node1.uuid()]["TestEmitFloat"])
         # unsubscribe
         self.node1.signal_unsubscribe(self.node2.uuid(), "TestRecvFloat", self.node1.uuid(), "TestEmitFloat")
-        #time.sleep(0.5)
+        # An unsubscribe results in:
+        # * whisper MOD, to update subscribers (self._on_modified)
+        # * whisper UNSUB, to the receiver or emitter
+        # We need to receive:
+        # * a forwarded UNSUB (in case of self emitter subscribe)
+        # * a MOD of the peer
+        # so we need to do two runs on both nodes
+        self.node2.run_once(5)
+        self.node1.run_once(5)
         self.node2.run_once(5)
         self.node1.run_once(5)
         self.assertNotIn("TestRecvFloat", self.node2.subscriptions.get(self.node1.uuid(), {}).get("TestEmitFloat", {}))


### PR DESCRIPTION
When a node subscribes its own emitter to a sensor it needs to wait for the forwarded subscription from the receiver peer. In the meantime a signal can be emitted but not send to the receiver as the forwarded
subscription is not yet received or parsed. However the emitter knew from the beginning that the receiver needed to receive the signal.

This PR fixes this. It already fills in the details during signal_(un)subscribe call.

Note: we are getting the same logic at multiple places. This is hard to maintain.
However I propose to fix that when the whole capability tree is refactored!

Also added unsubscribe to the unittest