### PR TITLE
Fix order of arguments in handle_UNSUB

### DIFF
--- a/examples/signal_3rdparty.py
+++ b/examples/signal_3rdparty.py
@@ -50,7 +50,7 @@ class SubscriptionMakerNode(ZOCP):
     def update_subscription(self):
         if self.subscribee_peer is not None and self.subscriber_peer is not None:
             if self.subscribe:
-                self.signal_subscribe(self.subscribee_peer, "My String", self.subscriber_peer, "My String")
+                self.signal_subscribe(self.subscriber_peer, "My String", self.subscribee_peer, "My String")
             else:
                 self.signal_unsubscribe(self.subscribee_peer, "My String", self.subscriber_peer, "My String")
 
@@ -61,5 +61,6 @@ if __name__ == '__main__':
 
     z = SubscriptionMakerNode("3rdparty@%s" % socket.gethostname())
     z.run()
+    del z
     print("FINISH")
 

--- a/examples/signal_subscribable.py
+++ b/examples/signal_subscribable.py
@@ -84,5 +84,5 @@ if __name__ == '__main__':
     z = SubscribableNode("subscribable@%s" % socket.gethostname())
     z.run()
     z.stop()
-    z = None
+    del z
     print("FINISH")

--- a/examples/signal_subscriber.py
+++ b/examples/signal_subscriber.py
@@ -30,5 +30,6 @@ if __name__ == '__main__':
 
     z = SubscriberNode("subscriber@%s" % socket.gethostname())
     z.run()
+    del z
     print("FINISH")
 

--- a/src/zocp.py
+++ b/src/zocp.py
@@ -775,7 +775,7 @@ class ZOCP(Pyre):
         if recv_peer != peer:
             # check if this should be forwarded (third party unsubscription request)
             logger.debug("ZOCP UNSUB   : forwarding unsubscription request: %s" % data)
-            self.signal_unsubscribe(recv_peer, receiver, emit_peer, emitter)
+            self.signal_unsubscribe(emit_peer, emitter, recv_peer, receiver)
             return
 
         if emitter is not None:


### PR DESCRIPTION
Commit https://github.com/sphaero/pyZOCP/commit/a7ff4523ba30872bb4d2fca4934b2a526bc79d78 changed (fixed?) the order of arguments in _handle_SUB, but did not change _handle_UNSUB. As a result, unsubscription is broken.

Also updates signal_* examples.