### PR TITLE
Fix unsubscription crash

### DIFF
--- a/examples/signal_3rdparty.py
+++ b/examples/signal_3rdparty.py
@@ -50,9 +50,9 @@ class SubscriptionMakerNode(ZOCP):
     def update_subscription(self):
         if self.subscribee_peer is not None and self.subscriber_peer is not None:
             if self.subscribe:
-                self.signal_subscribe(self.subscribee_peer, "My String", self.subscriber_peer, "My String")
+                self.signal_subscribe(self.subscriber_peer, "My String", self.subscribee_peer, "My String")
             else:
-                self.signal_unsubscribe(self.subscribee_peer, "My String", self.subscriber_peer, "My String")
+                self.signal_unsubscribe(self.subscriber_peer, "My String", self.subscribee_peer, "My String")
 
         
 if __name__ == '__main__':
@@ -61,5 +61,6 @@ if __name__ == '__main__':
 
     z = SubscriptionMakerNode("3rdparty@%s" % socket.gethostname())
     z.run()
+    del z
     print("FINISH")
 

--- a/examples/signal_subscribable.py
+++ b/examples/signal_subscribable.py
@@ -32,6 +32,7 @@ class SubscribableNode(ZOCP):
                     self.loop_time = time.time() + self.interval
                     self.on_timer()
             except (KeyboardInterrupt, SystemExit):
+                self.stop()
                 break
 
 
@@ -83,6 +84,5 @@ if __name__ == '__main__':
 
     z = SubscribableNode("subscribable@%s" % socket.gethostname())
     z.run()
-    z.stop()
-    z = None
+    del z
     print("FINISH")

--- a/examples/signal_subscriber.py
+++ b/examples/signal_subscriber.py
@@ -30,5 +30,6 @@ if __name__ == '__main__':
 
     z = SubscriberNode("subscriber@%s" % socket.gethostname())
     z.run()
+    del z
     print("FINISH")
 

--- a/src/zocp.py
+++ b/src/zocp.py
@@ -421,10 +421,10 @@ class ZOCP(Pyre):
                 emitter in self.subscribers[recv_peer] and
                 receiver in self.subscribers[recv_peer][emitter]):
                 self.subscribers[recv_peer][emitter].remove(receiver)
-            if not any(self.subscribers[recv_peer][emitter]):
-                self.subscribers[recv_peer].pop(emitter)
-            if not any(self.subscribers[recv_peer]):
-                self.subscribers.pop(recv_peer)
+                if not any(self.subscribers[recv_peer]):
+                    self.subscribers.pop(recv_peer)
+                elif not any(self.subscribers[recv_peer][emitter]):
+                    self.subscribers[recv_peer].pop(emitter)
 
             #self.on_peer_unsubscribed(peer, name, data)
 


### PR DESCRIPTION
While updating the signal_3rdparty example, I noticed ZOCP crashes when a node is unsubscribed from an emitter it was not subscribed to. This commit fixes that (while updating the signal_* examples for the recent switch in arguments for signal_subscribe and signal_unsubscribe.